### PR TITLE
update policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,23 +32,27 @@ resource "aws_ecr_repository_policy" "main" {
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "adds full ecr access to the ${var.repo_name} repository",
-            "Effect": "Allow",
-            "Principal": "*",
-            "Action": [
-                "ecr:BatchCheckLayerAvailability",
-                "ecr:BatchGetImage",
-                "ecr:CompleteLayerUpload",
-                "ecr:GetDownloadUrlForLayer",
-                "ecr:GetLifecyclePolicy",
-                "ecr:InitiateLayerUpload",
-                "ecr:PutImage",
-                "ecr:UploadLayerPart",
-                "ecr:ReplicateImage",
-                "ecr:CreateRepository"
-            ]
+          "Sid": "adds full ecr access to the ${var.repo_name} repository",
+          "Effect": "Allow",
+          "Principal": ${var.principal},
+          "Action": [
+              "ecr:BatchCheckLayerAvailability",
+              "ecr:BatchGetImage",
+              "ecr:CompleteLayerUpload",
+              "ecr:GetDownloadUrlForLayer",
+              "ecr:GetLifecyclePolicy",
+              "ecr:InitiateLayerUpload",
+              "ecr:PutImage",
+              "ecr:UploadLayerPart",
+              "ecr:ReplicateImage",
+              "ecr:CreateRepository",
+              "ecr:DescribeImages",
+              "ecr:DescribeRepositories",
+              "ecr:GetRepositoryPolicy",
+              "ecr:ListImages"
+          ]
         }
-        ]
+      ]
     }
     EOF
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,3 +25,7 @@ variable "replication_policy" {
     region     = "us-east-1"
   }
 }
+
+variable "principal" {
+  default = "\"*\""
+}


### PR DESCRIPTION
Changes to default policy, this enables us to pass a custom policy and allow sharing ECR between non-prod and prod, hence removing the need to replicate and saving costs of duplicate images,
no breaking changes if no principal is passed default value of "*" (same as until now is passed)